### PR TITLE
Fix custom taxonomy query structure in build_query_args method

### DIFF
--- a/RandomPostOnRefresh.php
+++ b/RandomPostOnRefresh.php
@@ -280,8 +280,11 @@ if ( ! class_exists( 'RandomPostOnRefresh' ) ) {
 					$query_args['tag__in'] = $terms;
 				} else {
 					$query_args['tax_query'] = array(
-						'taxonomy' => $atts['taxonomy'],
-						'terms'    => $terms,
+						array(
+							'taxonomy' => $atts['taxonomy'],
+							'field'    => 'term_id',
+							'terms'    => $terms,
+						),
 					);
 				}
 			}

--- a/tests/RandomPostOnRefreshTest.php
+++ b/tests/RandomPostOnRefreshTest.php
@@ -134,6 +134,27 @@ class RandomPostOnRefreshTest extends TestCase {
 		$args = RandomPostOnRefresh::build_query_args( $atts );
 		$this->assertEquals( array( 3, 4 ), $args['category__in'] );
 	}
+	
+	/**
+	 * Test build_query_args with custom taxonomy and terms.
+	 */
+	public function test_build_query_args_with_custom_taxonomy() {
+		$atts = array_merge(
+			RandomPostOnRefresh::DEFAULT_ATTRIBUTES,
+			array(
+				'post_type' => 'post',
+				'taxonomy'  => 'custom_tax',
+				'terms'     => '5,6',
+			)
+		);
+		$args = RandomPostOnRefresh::build_query_args( $atts );
+		$this->assertArrayHasKey( 'tax_query', $args );
+		$this->assertIsArray( $args['tax_query'] );
+		$this->assertIsArray( $args['tax_query'][0] );
+		$this->assertEquals( 'custom_tax', $args['tax_query'][0]['taxonomy'] );
+		$this->assertEquals( 'term_id', $args['tax_query'][0]['field'] );
+		$this->assertEquals( array( 5, 6 ), $args['tax_query'][0]['terms'] );
+	}
 
 	/**
 	 * Test build_query_args with show=image and image_required=true.


### PR DESCRIPTION
## Summary
- Fixed a bug in the  method where custom taxonomy queries were not structured correctly for WP_Query
- The parameter requires an array of arrays, and was previously implemented as a flat array
- Added a new unit test to verify the proper structure for custom taxonomy queries

## Test plan
1. Run the unit tests to verify the proper query structure
2. Test the shortcode with a custom taxonomy filter to confirm posts are filtered correctly

🤖 Generated with [Claude Code](https://claude.ai/code)